### PR TITLE
Find SAS from PATH on windows platform

### DIFF
--- a/R/find_sas.r
+++ b/R/find_sas.r
@@ -20,7 +20,19 @@ find_sas <- function(message=TRUE) {
           }
         }
       }
-    }
+  }
+  
+  if (is.null(sasexe)) {    
+      # SAS is not found at default location in windows
+      # Try to find it from PATH
+      sasexe <- Sys.which("sas")
+      attr(sasexe, "names") <- NULL    # remove attr so this is plain text like other branch
+      if (nchar(sasexe) > 0) {
+          if (message) message("SAS found at ", sasexe)
+      } else {
+          sasexe <- NULL    # change the 0-length `sasexe` back to `NULL`
+      }
+  }
   
 } else if (Sys.info()["sysname"]=="Darwin") {
   sasexe <- NULL

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ You can install these as an R package:
 install.packages("SASmarkdown")
 # or use
 devtools::install_github("Hemken/SASmarkdown")
+# devtools::install_github("Hemken/SASmarkdown", build_vignettes = TRUE)    # build vignettes locally
 ```
 Then you can check with
 ```

--- a/vignettes/spinSASmarkdown.rmd
+++ b/vignettes/spinSASmarkdown.rmd
@@ -114,7 +114,7 @@ writeLines(indoc, "indoc.sas")
 
 To process this document then, simply use
 
-```{r spin, comment=NA, results="hide"}
+```{r spin, comment=NA, results="hide", message=FALSE}
 library(SASmarkdown)
 spinsas("indoc.sas")
 ```
@@ -122,7 +122,7 @@ spinsas("indoc.sas")
 Which gives a document, \"indoc.html\" that looks like
 
 <hr>
-```{r output, child="indoc.html"}
+```{r output, child="indoc.md"}
 ```
 
 ```{r cleanup, echo=FALSE, results="hide"}

--- a/vignettes/spinSASmarkdown.rmd
+++ b/vignettes/spinSASmarkdown.rmd
@@ -45,14 +45,12 @@ the end of a line.
 - Your chunk of SAS code must end with a semi-colon (not a block comment).
 
 ## Example
-  In order to run SAS code, first we specify a path for SAS and set up some options in R.
+  In order to run SAS code, first we load the `SASmarkdown` library so it can automatically set up some necessary options in R.
 ```
 *+ setup, message=FALSE ;
 
 *R 
 library(SASmarkdown)
-sasexe <- 'C:/Program Files/SASHome/SASFoundation/9.4/sas.exe'
-sasopts <- '-nosplash -ls 75'
 ;
 ```
 Text is then included as a special comment.
@@ -63,8 +61,7 @@ Text is then included as a special comment.
 Finally, the executable SAS code is given a line of chunk instructions.
 
 ```
-*+  example1, engine='sas', engine.path=list(sas=saspath), engine.opts=list(sas=sasopts), 
-comment=NA;
+*+  example1, engine='sas', comment=NA;
 
 proc means data=sashelp.class /*(keep = age)*/;
 run;
@@ -84,14 +81,11 @@ The entire document might be:
 
 *R 
 library(SASmarkdown)
-sasexe <- 'C:/Program Files/SASHome/SASFoundation/9.4/sas.exe'
-sasopts <- '-nosplash -ls 75'
 ;
 
 ** The report begins here.;
 
-*+  example1, engine='sas', engine.path=list(sas=sasexe), engine.opts=list(sas=sasopts),
-comment=NA;
+*+  example1, engine='sas', comment=NA;
 
 proc means data=sashelp.class /*(keep = age)*/;
 run;
@@ -106,14 +100,11 @@ indoc <- "
 
 *R 
 library(SASmarkdown)
-sasexe <- 'C:/Program Files/SASHome/SASFoundation/9.4/sas.exe'
-sasopts <- '-nosplash -ls 75'
 ;
 
 ** The report begins here.;
 
-*+  example1, engine='sas', engine.path=list(sas=sasexe), engine.opts=list(sas=sasopts), 
-comment=NA;
+*+  example1, engine='sas', comment=NA;
 
 proc means data=sashelp.class /*(keep = age)*/;
 run;


### PR DESCRIPTION
This mainly addresses issue #18 , now in `find_sas()` if the executable is not found at the default path on windows, it will try to use `Sys.which` to determine if the excecutable is at other location in PATH.

Also in `readme` I added a comment about building the vignettes locally along with the installation process since the vignettes is not available on cran or the  default `install_github` process.

Lastly I adjust the `spinSASmarkdown` vignette: now that the package can automatically set the necessary options for knit there's no need to manually set those options. So I just tidy up some content. Also at the last bit I changed the child document to `indoc.md` instead of the original `indoc.html` since directly including a full html file as child document will cause some rendering issue, e.g. the unexpected `!<IDOCTYPE> html` in the resulting vignette.